### PR TITLE
fix: added the fix in auto deploy github actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Build project
         run: npm run build
 
+      - name: Create 404.html for SPA routing
+        run: cp dist/index.html dist/404.html
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Summary
This pull request updates the GitHub Actions deployment workflow to correctly support client‑side routing for the React + Vite application hosted on GitHub Pages. The workflow now generates a 404.html file during the build process to ensure that deep links and page refreshes work across all routes.

Changes

- Added a workflow step to duplicate dist/index.html as dist/404.html
- Ensures GitHub Pages serves the SPA fallback for any unknown route
- Keeps the existing build and deployment steps unchanged

Reasoning
GitHub Pages is a static host and does not understand client‑side routes. When a user directly visits a nested path (e.g., /dashboard, /profile), GitHub Pages attempts to load a physical file at that path and returns a 404.
By creating a 404.html that mirrors index.html, GitHub Pages always loads the React application, allowing React Router to resolve the route correctly.

Impact

- Fixes broken deep links and refresh behavior on all routes
- No changes to application logic or UI
- Deployment remains stable and compatible with Vite
- Low‑risk configuration improvement